### PR TITLE
feat: replace CV with hyper-casual Gate Runner browser game

### DIFF
--- a/cv/index.html
+++ b/cv/index.html
@@ -1,118 +1,29 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Currículum de Nahuel Alegre</title>
-  <meta name="description" content="Curriculum Vitae de Nahuel Alegre, desarrollador web." />
-  <link rel="icon" href="/favicon.ico" />
-  <link rel="manifest" href="/manifest.json" />
-  <meta name="theme-color" content="#009688" />
-  <meta property="og:title" content="Currículum de Nahuel Alegre" />
-  <meta property="og:description" content="Curriculum Vitae de Nahuel Alegre, desarrollador web." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="" />
-  <meta property="og:image" content="/icon-512.png" />
-  <meta name="twitter:card" content="summary" />
-  <link rel="prefetch" href="/src/data.js" as="script" />
+  <title>Hyper-Casual Gate Runner</title>
   <link rel="stylesheet" href="/src/style.css" />
 </head>
 <body>
-  <header>
-    <nav>
-      <button id="menu-toggle" class="menu-toggle" aria-label="Menú">☰</button>
-      <ul id="menu" class="menu">
-        <li><a href="#about">Sobre mí</a></li>
-        <li><a href="#projects">Proyectos</a></li>
-        <li><a href="#experience">Experiencia</a></li>
-        <li><a href="#education">Educación</a></li>
-        <li><a href="#skills">Habilidades</a></li>
-        <li><a href="#contact">Contacto</a></li>
-      </ul>
-      <div class="switches">
-        <button id="theme-toggle" aria-label="Cambiar tema">🌓</button>
-        <button id="accent-toggle" aria-label="Cambiar color de acento">🎨</button>
-      </div>
-    </nav>
-    <section id="hero">
-      <h1 id="nombre"></h1>
-      <p id="titulo"></p>
-      <div class="cta">
-        <button id="download-btn">Descargar PDF</button>
-        <div class="links">
-          <button id="email-copy" aria-label="Copiar email"></button>
-          <button id="phone-copy" aria-label="Copiar teléfono"></button>
-          <a id="linkedin-link" href="#" target="_blank" rel="noopener" aria-label="LinkedIn">LinkedIn</a>
-        </div>
-      </div>
-    </section>
-  </header>
-  <main>
-    <section id="about" class="container">
-      <h2>Sobre mí</h2>
-      <p id="resumen"></p>
-    </section>
-    <section id="projects" class="container">
-      <h2>Proyectos</h2>
-      <div id="project-grid"></div>
-    </section>
-    <section id="experience" class="container">
-      <h2>Experiencia</h2>
-      <ul id="experience-list"></ul>
-    </section>
-    <section id="education" class="container">
-      <h2>Educación</h2>
-      <div id="education-list"></div>
-    </section>
-    <section id="skills" class="container">
-      <h2>Habilidades</h2>
-      <input type="search" id="skill-search" aria-label="Buscar habilidades" placeholder="Buscar" />
-      <div id="skill-filters">
-        <button data-group="all" class="active">Todas</button>
-        <button data-group="front">Front</button>
-        <button data-group="backend">Backend</button>
-        <button data-group="db">BD</button>
-        <button data-group="ofimatica">Ofimática</button>
-      </div>
-      <ul id="skill-list"></ul>
-    </section>
-    <section id="languages" class="container">
-      <h2>Idiomas</h2>
-      <ul id="language-list"></ul>
-    </section>
-    <section id="testimonials" class="container">
-      <h2>Testimonios</h2>
-      <div id="testimonial-list"></div>
-    </section>
-    <section id="achievements" class="container">
-      <h2>Logros y certificaciones</h2>
-      <ul id="achievement-list"></ul>
-    </section>
-    <section id="interests" class="container">
-      <h2>Intereses</h2>
-      <ul id="interest-list"></ul>
-    </section>
-    <section id="contact" class="container">
-      <h2>Contacto</h2>
-      <div class="contact-buttons">
-        <a id="email-link" href="#" class="contact-btn">Email</a>
-        <a id="phone-link" href="#" class="contact-btn">Teléfono</a>
-      </div>
-      <form id="contact-form">
-        <label>Nombre<input type="text" name="name" required /></label>
-        <label>Email<input type="email" name="email" required /></label>
-        <label>Mensaje<textarea name="message" required></textarea></label>
-        <label><input type="checkbox" required /> Acepto el aviso de privacidad</label>
-        <button type="submit">Enviar</button>
-      </form>
-      <p class="privacy">Los datos se envían por correo. No se realiza seguimiento.</p>
-    </section>
+  <main class="game-shell">
+    <header class="hud">
+      <div class="hud-pill">Level <strong id="level">1</strong></div>
+      <div class="hud-pill">Health <strong id="health">1.0</strong></div>
+      <div class="hud-pill">Damage <strong id="damage">1.0</strong></div>
+      <div class="hud-pill">Coins <strong id="coins">0</strong></div>
+      <div class="hud-pill">Score <strong id="score">0</strong></div>
+    </header>
+
+    <canvas id="game" width="420" height="760" aria-label="Gate runner game canvas"></canvas>
+
+    <div class="controls">
+      <p>Move: <kbd>←</kbd><kbd>→</kbd> or <kbd>A</kbd><kbd>D</kbd> • Restart: <kbd>R</kbd></p>
+      <p id="status">Choose blue gates, avoid red enemies and projectiles.</p>
+    </div>
   </main>
-  <footer>
-    <p>&copy; <span id="year"></span> <span id="footer-name"></span></p>
-    <p class="visits">Visitas: <span id="visit-count"></span></p>
-  </footer>
-  <div id="toast" role="status" aria-live="polite" class="hidden"></div>
+
   <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/cv/src/main.js
+++ b/cv/src/main.js
@@ -1,265 +1,195 @@
-import { cvData } from './data.js';
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
 
-// Populate basic info
-const nombreEl = document.getElementById('nombre');
-const tituloEl = document.getElementById('titulo');
-const resumenEl = document.getElementById('resumen');
-const yearEl = document.getElementById('year');
-const footerNameEl = document.getElementById('footer-name');
-
-// visit counter
-const visitEl = document.getElementById('visit-count');
-const visits = Number(localStorage.getItem('visits') || 0) + 1;
-localStorage.setItem('visits', visits);
-if (visitEl) visitEl.textContent = visits;
-
-nombreEl.textContent = cvData.nombre;
-tituloEl.textContent = cvData.experiencia[0]?.rol || '';
-resumenEl.textContent = cvData.resumen;
-yearEl.textContent = new Date().getFullYear();
-footerNameEl.textContent = cvData.nombre;
-
-// Hero links
-const emailLink = document.getElementById('email-link');
-const phoneLink = document.getElementById('phone-link');
-const emailCopy = document.getElementById('email-copy');
-const phoneCopy = document.getElementById('phone-copy');
-const linkedinLink = document.getElementById('linkedin-link');
-const menuToggle = document.getElementById('menu-toggle');
-const menu = document.getElementById('menu');
-
-emailLink.href = `mailto:${cvData.contacto.email}`;
-phoneLink.href = `tel:${cvData.contacto.telefono}`;
-emailLink.textContent = cvData.contacto.email;
-phoneLink.textContent = cvData.contacto.telefono;
-emailCopy.textContent = 'Copiar email';
-phoneCopy.textContent = 'Copiar tel';
-linkedinLink.href = cvData.contacto.linkedin;
-
-menuToggle.addEventListener('click', () => menu.classList.toggle('open'));
-
-// Copy to clipboard
-themesInit();
-function copy(text) {
-  navigator.clipboard.writeText(text).then(() => {
-    showToast('Copiado al portapapeles');
-  });
-}
-emailCopy.addEventListener('click', () => copy(cvData.contacto.email));
-phoneCopy.addEventListener('click', () => copy(cvData.contacto.telefono));
-
-// Experience timeline
-const expList = document.getElementById('experience-list');
-cvData.experiencia.forEach((exp, idx) => {
-  const li = document.createElement('li');
-  const btn = document.createElement('button');
-  btn.className = 'exp-item';
-  btn.setAttribute('aria-expanded', 'false');
-  btn.innerHTML = `<span>${exp.empresa} - ${exp.rol}</span> <time>${exp.inicio} - ${exp.fin}</time>`;
-  const details = document.createElement('div');
-  details.className = 'exp-details';
-  details.hidden = true;
-  const respList = document.createElement('ul');
-  exp.responsabilidades.forEach(r => {
-    const rli = document.createElement('li');
-    rli.textContent = r;
-    respList.appendChild(rli);
-  });
-  const chips = document.createElement('div');
-  chips.className = 'chips';
-  exp.tecnologias.forEach(t => {
-    const chip = document.createElement('span');
-    chip.textContent = t;
-    chips.appendChild(chip);
-  });
-  details.appendChild(respList);
-  details.appendChild(chips);
-  li.appendChild(btn);
-  li.appendChild(details);
-  expList.appendChild(li);
-  const toggle = () => {
-    const expanded = btn.getAttribute('aria-expanded') === 'true';
-    btn.setAttribute('aria-expanded', String(!expanded));
-    details.hidden = expanded;
-  };
-  btn.addEventListener('click', toggle);
-  btn.addEventListener('keydown', e => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      toggle();
-    }
-  });
-});
-
-// Education
-const eduList = document.getElementById('education-list');
-cvData.educacion.forEach(edu => {
-  const card = document.createElement('article');
-  card.innerHTML = `<h3>${edu.institucion}</h3><p>${edu.titulo} (${edu.estado})</p><p>${edu.inicio} - ${edu.fin}</p>`;
-  eduList.appendChild(card);
-});
-
-// Skills with filters
-const skillSearch = document.getElementById('skill-search');
-const skillFilters = document.querySelectorAll('#skill-filters button');
-const skillList = document.getElementById('skill-list');
-const allSkills = [];
-Object.entries(cvData.habilidades).forEach(([group, items]) => {
-  items.forEach(name => allSkills.push({ group, name }));
-});
-let currentGroup = 'all';
-function renderSkills() {
-  const term = skillSearch.value.toLowerCase();
-  skillList.innerHTML = '';
-  allSkills.filter(s => (currentGroup === 'all' || s.group === currentGroup) && s.name.toLowerCase().includes(term))
-    .forEach(s => {
-      const li = document.createElement('li');
-      li.textContent = s.name;
-      skillList.appendChild(li);
-    });
-}
-skillSearch.addEventListener('input', renderSkills);
-skillFilters.forEach(btn => {
-  btn.addEventListener('click', () => {
-    currentGroup = btn.dataset.group;
-    skillFilters.forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-    renderSkills();
-  });
-});
-renderSkills();
-
-// Languages
-const langList = document.getElementById('language-list');
-cvData.idiomas.forEach(lang => {
-  const li = document.createElement('li');
-  li.innerHTML = `<span>${lang.idioma} (${lang.nivel})</span><div class="language-bar"><span style="width:${nivelToPercent(lang.nivel)}%"></span></div><small>${lang.detalle}</small>`;
-  langList.appendChild(li);
-});
-function nivelToPercent(nivel) {
-  const map = { A1:20, A2:30, B1:40, B2:60, C1:80, C2:100 };
-  return map[nivel] || 50;
-}
-
-// Projects
-const projectGrid = document.getElementById('project-grid');
-cvData.proyectos.forEach(p => {
-  const card = document.createElement('article');
-  card.className = 'project-card card';
-  card.innerHTML = `
-    <img src="${p.imagen}" alt="${p.titulo}" loading="lazy" />
-    <div class="card-content">
-      <h3>${p.titulo}</h3>
-      <p>${p.descripcion}</p>
-      <a href="${p.url}" target="_blank" rel="noopener">Ver proyecto</a>
-    </div>`;
-  projectGrid.appendChild(card);
-});
-
-// Testimonials
-const testimonialList = document.getElementById('testimonial-list');
-cvData.testimonios.forEach(t => {
-  const fig = document.createElement('figure');
-  fig.className = 'testimonial card';
-  fig.innerHTML = `<blockquote>“${t.comentario}”</blockquote><cite>${t.nombre} - ${t.rol}</cite>`;
-  testimonialList.appendChild(fig);
-});
-
-// Achievements
-const achievementList = document.getElementById('achievement-list');
-cvData.certificaciones.forEach(c => {
-  const li = document.createElement('li');
-  li.className = 'card';
-  li.innerHTML = `<strong>${c.titulo}</strong><br><small>${c.entidad} - ${c.anio}</small>`;
-  achievementList.appendChild(li);
-});
-
-// Interests
-const interestList = document.getElementById('interest-list');
-cvData.intereses.forEach(i => {
-  const li = document.createElement('li');
-  li.textContent = i;
-  interestList.appendChild(li);
-});
-
-// Contact form
-const form = document.getElementById('contact-form');
-form.addEventListener('submit', e => {
-  e.preventDefault();
-  showToast('Mensaje enviado');
-  form.reset();
-});
-
-// Theme and accent toggles
-function themesInit() {
-  const themeToggle = document.getElementById('theme-toggle');
-  const accentToggle = document.getElementById('accent-toggle');
-  const storedTheme = localStorage.getItem('theme') || 'light';
-  const storedAccent = localStorage.getItem('accent') || 'teal';
-  document.documentElement.setAttribute('data-theme', storedTheme);
-  document.documentElement.setAttribute('data-accent', storedAccent);
-  themeToggle.addEventListener('click', () => {
-    const current = document.documentElement.getAttribute('data-theme');
-    const next = current === 'light' ? 'dark' : 'light';
-    document.documentElement.setAttribute('data-theme', next);
-    localStorage.setItem('theme', next);
-  });
-  const accents = ['teal', 'orange', 'blue'];
-  accentToggle.addEventListener('click', () => {
-    const current = document.documentElement.getAttribute('data-accent');
-    const idx = accents.indexOf(current);
-    const next = accents[(idx + 1) % accents.length];
-    document.documentElement.setAttribute('data-accent', next);
-    localStorage.setItem('accent', next);
-  });
-}
-
-// Intersection Observer animations
-const observer = new IntersectionObserver(entries => {
-  entries.forEach(entry => {
-    if (entry.isIntersecting) {
-      entry.target.classList.add('in-view');
-      observer.unobserve(entry.target);
-    }
-  });
-});
-document.querySelectorAll('section').forEach(sec => observer.observe(sec));
-
-// Download PDF
-const downloadBtn = document.getElementById('download-btn');
-downloadBtn.addEventListener('click', () => window.print());
-
-// Toast helper
-function showToast(text) {
-  const toast = document.getElementById('toast');
-  toast.textContent = text;
-  toast.classList.add('show');
-  setTimeout(() => toast.classList.remove('show'), 2000);
-}
-
-// Service worker
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
-  });
-}
-
-// JSON-LD
-const ld = {
-  '@context': 'https://schema.org',
-  '@type': 'Person',
-  name: cvData.nombre,
-  email: cvData.contacto.email,
-  telephone: cvData.contacto.telefono,
-  sameAs: [cvData.contacto.linkedin],
-  jobTitle: cvData.experiencia[0]?.rol,
-  worksFor: {
-    '@type': 'Organization',
-    name: cvData.experiencia[0]?.empresa
-  }
+const ui = {
+  level: document.getElementById('level'),
+  health: document.getElementById('health'),
+  damage: document.getElementById('damage'),
+  coins: document.getElementById('coins'),
+  score: document.getElementById('score'),
+  status: document.getElementById('status')
 };
-const ldScript = document.createElement('script');
-ldScript.type = 'application/ld+json';
-ldScript.textContent = JSON.stringify(ld);
-document.head.appendChild(ldScript);
 
+const W = canvas.width;
+const H = canvas.height;
+const lanes = [W * 0.35, W * 0.5, W * 0.65];
+
+const state = {
+  t: 0,
+  speed: 3.2,
+  lane: 1,
+  x: lanes[1],
+  y: H - 80,
+  health: 1,
+  damage: 1,
+  coins: 0,
+  score: 0,
+  level: 1,
+  dead: false,
+  rows: [],
+  bullets: [],
+  enemyBullets: [],
+  touchX: null
+};
+
+function spawnRow(y = -120) {
+  const roll = Math.random();
+  if (roll < 0.45) {
+    const goodLane = Math.floor(Math.random() * 3);
+    state.rows.push({ type: 'gates', y, goodLane, badPenalty: 0.6, goodBoost: 0.5 });
+  } else {
+    const occupied = new Set([Math.floor(Math.random() * 3), Math.floor(Math.random() * 3)]);
+    state.rows.push({ type: 'enemies', y, occupied: [...occupied] });
+  }
+}
+for (let i = 0; i < 5; i++) spawnRow(-i * 180);
+
+function shootPlayer() {
+  state.bullets.push({ x: state.x, y: state.y - 25, vy: -8, dmg: state.damage });
+}
+setInterval(() => !state.dead && shootPlayer(), 350);
+
+function moveLane(dir) {
+  state.lane = Math.max(0, Math.min(2, state.lane + dir));
+}
+addEventListener('keydown', e => {
+  if (e.key === 'ArrowLeft' || e.key.toLowerCase() === 'a') moveLane(-1);
+  if (e.key === 'ArrowRight' || e.key.toLowerCase() === 'd') moveLane(1);
+  if (e.key.toLowerCase() === 'r' && state.dead) location.reload();
+});
+canvas.addEventListener('pointerdown', e => state.touchX = e.clientX);
+canvas.addEventListener('pointermove', e => {
+  if (state.touchX == null) return;
+  const dx = e.clientX - state.touchX;
+  if (Math.abs(dx) > 25) {
+    moveLane(dx > 0 ? 1 : -1);
+    state.touchX = e.clientX;
+  }
+});
+canvas.addEventListener('pointerup', () => state.touchX = null);
+
+function update() {
+  if (state.dead) return;
+  state.t += 1;
+  state.x += (lanes[state.lane] - state.x) * 0.2;
+  state.score += 1;
+
+  for (const row of state.rows) {
+    row.y += state.speed;
+    if (row.type === 'enemies' && Math.random() < 0.03) {
+      row.occupied.forEach(l => {
+        state.enemyBullets.push({ x: lanes[l], y: row.y + 8, vy: 5 });
+      });
+    }
+    if (row.y > state.y - 40 && row.y < state.y + 8) {
+      if (row.type === 'gates') {
+        if (state.lane === row.goodLane) {
+          state.damage += row.goodBoost;
+          state.coins += 2;
+          ui.status.textContent = 'Blue gate! Damage and ammo boosted.';
+        } else {
+          state.health = Math.max(0, state.health - row.badPenalty);
+          ui.status.textContent = 'Red gate penalty!';
+        }
+        row.hit = true;
+      }
+      if (row.type === 'enemies' && row.occupied.includes(state.lane)) {
+        state.health = Math.max(0, state.health - 0.35);
+        ui.status.textContent = 'You ran into enemies!';
+      }
+    }
+  }
+
+  state.rows = state.rows.filter(r => r.y < H + 80);
+  if (state.rows.length < 6) spawnRow();
+
+  state.bullets.forEach(b => b.y += b.vy);
+  state.enemyBullets.forEach(b => b.y += b.vy);
+  state.bullets = state.bullets.filter(b => b.y > -40);
+  state.enemyBullets = state.enemyBullets.filter(b => b.y < H + 40);
+
+  state.enemyBullets.forEach(b => {
+    if (Math.abs(b.x - state.x) < 16 && Math.abs(b.y - state.y) < 18) {
+      state.health = Math.max(0, state.health - 0.15);
+      b.y = H + 200;
+    }
+  });
+
+  if (state.health <= 0) {
+    state.dead = true;
+    ui.status.textContent = 'Game over. Press R to restart.';
+  }
+
+  state.level = 1 + Math.floor(state.score / 1000);
+  state.speed = 3.2 + state.level * 0.15;
+
+  ui.level.textContent = state.level;
+  ui.health.textContent = state.health.toFixed(1);
+  ui.damage.textContent = state.damage.toFixed(1);
+  ui.coins.textContent = state.coins;
+  ui.score.textContent = state.score;
+}
+
+function draw() {
+  ctx.clearRect(0, 0, W, H);
+
+  ctx.fillStyle = '#e5b98d';
+  ctx.fillRect(0, 0, W, H);
+  ctx.fillStyle = '#453b55';
+  ctx.fillRect(W * 0.2, 0, W * 0.6, H);
+  ctx.strokeStyle = '#7e7391';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(W * 0.2, 0, W * 0.6, H);
+
+  ctx.setLineDash([16, 14]);
+  ctx.strokeStyle = '#978ca9';
+  ctx.beginPath();
+  ctx.moveTo(W * 0.5, 0);
+  ctx.lineTo(W * 0.5, H);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  for (const row of state.rows) {
+    if (row.type === 'gates') {
+      for (let l = 0; l < 3; l++) {
+        ctx.fillStyle = l === row.goodLane ? '#22a8ff' : '#ff3848';
+        ctx.fillRect(lanes[l] - 30, row.y, 60, 54);
+      }
+    } else {
+      row.occupied.forEach(l => {
+        ctx.fillStyle = '#d6273d';
+        ctx.beginPath();
+        ctx.arc(lanes[l], row.y + 20, 13, 0, Math.PI * 2);
+        ctx.fill();
+      });
+    }
+  }
+
+  ctx.fillStyle = '#4fc3ff';
+  ctx.beginPath();
+  ctx.arc(state.x, state.y - 12, 9, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = '#2f3f5c';
+  ctx.fillRect(state.x - 8, state.y - 8, 16, 24);
+
+  ctx.fillStyle = '#f4e16f';
+  state.bullets.forEach(b => ctx.fillRect(b.x - 2, b.y, 4, 10));
+  ctx.fillStyle = '#ff6767';
+  state.enemyBullets.forEach(b => ctx.fillRect(b.x - 2, b.y, 4, 9));
+
+  if (state.dead) {
+    ctx.fillStyle = 'rgba(0,0,0,.45)';
+    ctx.fillRect(0,0,W,H);
+    ctx.fillStyle = '#fff';
+    ctx.font = '700 34px Inter, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('GAME OVER', W/2, H/2);
+  }
+}
+
+function frame() {
+  update();
+  draw();
+  requestAnimationFrame(frame);
+}
+frame();

--- a/cv/src/style.css
+++ b/cv/src/style.css
@@ -1,435 +1,49 @@
 :root {
-  --accent: #009688;
-  --bg: #fdfdfd;
-  --fg: #111;
-  --surface: rgba(255,255,255,0.7);
-  --radius: 12px;
-  --shadow: 0 4px 20px rgba(0,0,0,0.1);
+  --bg: #f6d2a7;
+  --road: #3f384d;
+  --lane: #8c829f;
+  --text: #111;
 }
 
-[data-theme="dark"] {
-  --bg: #0f0f0f;
-  --fg: #f1f1f1;
-  --surface: rgba(0,0,0,0.4);
-  --shadow: 0 4px 20px rgba(0,0,0,0.6);
-}
-
-[data-accent="orange"] { --accent: #ff9800; }
-[data-accent="blue"] { --accent: #2196f3; }
-
-html {
-  scroll-behavior: smooth;
-  font-size: clamp(16px, 1.6vw, 18px);
-}
-
+* { box-sizing: border-box; }
 body {
   margin: 0;
+  min-height: 100vh;
   font-family: Inter, system-ui, sans-serif;
-  background: var(--bg);
-  color: var(--fg);
-  line-height: 1.6;
-  transition: background 0.3s, color 0.3s;
-}
-
-nav {
-  position: sticky;
-  top: 0;
-  z-index: 100;
-  backdrop-filter: blur(8px);
-  background: var(--surface);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 1rem;
-}
-
-nav .menu {
-  list-style: none;
-  display: flex;
-  gap: 1rem;
-  margin: 0;
-  padding: 0;
-}
-
-nav .menu a {
-  text-decoration: none;
-  color: inherit;
-  padding: 0.25rem 0.5rem;
-  border-radius: var(--radius);
-  transition: background 0.3s;
-}
-
-nav .menu a:hover {
-  background: var(--accent);
-  color: #fff;
-}
-
-.menu-toggle {
-  display: none;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  color: inherit;
-}
-
-.switches {
-  display: flex;
-  gap: 0.5rem;
-}
-
-#hero {
-  min-height: 70vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  background: linear-gradient(135deg, var(--accent), var(--accent) 60%, var(--bg));
-  color: #fff;
-  position: relative;
-  overflow: hidden;
-}
-
-#hero .cta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  justify-content: center;
-  align-items: center;
-}
-
-#hero .links {
-  display: flex;
-  gap: 0.5rem;
-}
-
-button {
-  cursor: pointer;
-  border: none;
-  border-radius: var(--radius);
-  background: var(--accent);
-  color: #fff;
-  padding: 0.5rem 1rem;
-  transition: transform 0.3s, box-shadow 0.3s, background 0.3s;
-}
-
-button:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow);
-}
-
-a {
-  color: var(--accent);
-}
-
-.container {
+  background: radial-gradient(circle at top, #f9dfbe, var(--bg));
+  color: var(--text);
   display: grid;
-  gap: 1.5rem;
-  padding: 2rem 1rem;
+  place-items: center;
 }
-
-@media (min-width: 768px) {
-  header, section, footer {
-    max-width: 960px;
-    margin: auto;
-  }
+.game-shell { width: min(95vw, 520px); }
+.hud {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0,1fr));
+  gap: .5rem;
+  margin-bottom: .5rem;
 }
-
-section {
-  opacity: 0;
-  transform: translateY(2rem);
-  transition: opacity 0.6s, transform 0.6s;
+.hud-pill {
+  background: rgba(255,255,255,.75);
+  border: 1px solid rgba(0,0,0,.1);
+  border-radius: 999px;
+  padding: .35rem .6rem;
+  font-size: .85rem;
+  text-align: center;
 }
-
-section.in-view {
-  opacity: 1;
-  transform: none;
-}
-
-.card {
-  background: var(--surface);
-  backdrop-filter: blur(10px);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  padding: 1rem;
-}
-
-.project-card img {
+canvas {
   width: 100%;
   height: auto;
-  display: block;
-  border-radius: var(--radius) var(--radius) 0 0;
+  border-radius: 14px;
+  border: 2px solid rgba(0,0,0,.2);
+  box-shadow: 0 18px 40px rgba(0,0,0,.25);
+  touch-action: none;
+  background: #d9b489;
 }
-
-.project-card .card-content {
-  padding-top: 0.5rem;
+.controls {
+  margin-top: .5rem;
+  background: rgba(255,255,255,.75);
+  border-radius: 10px;
+  padding: .65rem .8rem;
+  font-size: .9rem;
 }
-
-#project-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.testimonial blockquote {
-  margin: 0;
-  font-style: italic;
-}
-
-.testimonial cite {
-  display: block;
-  margin-top: 0.5rem;
-  font-weight: 600;
-}
-
-#achievement-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-#interest-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-#interest-list li {
-  background: var(--accent);
-  color: #fff;
-  padding: 0.25rem 0.75rem;
-  border-radius: var(--radius);
-}
-
-#experience-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-#experience-list li {
-  position: relative;
-  padding-left: 1.5rem;
-  margin-bottom: 1rem;
-  border-left: 2px solid var(--accent);
-}
-
-#experience-list li::before {
-  content: '';
-  position: absolute;
-  left: -6px;
-  top: 0.5rem;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--accent);
-}
-
-.exp-item {
-  background: none;
-  color: inherit;
-  padding: 0;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  font-weight: 600;
-}
-
-.exp-item time {
-  font-size: 0.875rem;
-  opacity: 0.7;
-}
-
-.exp-details {
-  margin-top: 0.5rem;
-}
-
-.chips span {
-  display: inline-block;
-  padding: 0.25rem 0.5rem;
-  background: var(--accent);
-  color: #fff;
-  border-radius: 12px;
-  margin: 0.25rem;
-  font-size: 0.875rem;
-}
-
-#education-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-#education-list article {
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  padding: 1rem;
-  background: var(--surface);
-}
-
-#skill-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 1rem 0;
-}
-
-#skill-filters button {
-  background: transparent;
-  border: 1px solid var(--accent);
-  color: var(--accent);
-  padding: 0.25rem 0.75rem;
-}
-
-#skill-filters button.active {
-  background: var(--accent);
-  color: #fff;
-}
-
-#skill-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-#skill-list li {
-  background: #e0e0e0;
-  padding: 0.25rem 0.5rem;
-  border-radius: var(--radius);
-}
-
-[data-theme="dark"] #skill-list li {
-  background: #424242;
-  color: #fff;
-}
-
-#language-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: 1rem;
-}
-
-#language-list li {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.language-bar {
-  background: #ccc;
-  border-radius: 4px;
-  height: 1rem;
-}
-
-.language-bar span {
-  display: block;
-  height: 100%;
-  background: var(--accent);
-  border-radius: 4px;
-}
-
-.contact-buttons {
-  display: flex;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.contact-btn {
-  background: var(--accent);
-  color: #fff;
-  padding: 0.5rem 1rem;
-  border-radius: var(--radius);
-  text-decoration: none;
-}
-
-#contact-form {
-  display: grid;
-  gap: 1rem;
-}
-
-#contact-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-input,
-textarea {
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: var(--radius);
-  background: var(--bg);
-  color: var(--fg);
-}
-
-input:focus-visible,
-textarea:focus-visible {
-  outline: 2px solid var(--accent);
-}
-
-#toast {
-  position: fixed;
-  bottom: 1rem;
-  right: 1rem;
-  background: var(--accent);
-  color: #fff;
-  padding: 0.5rem 1rem;
-  border-radius: var(--radius);
-  opacity: 0;
-  transition: opacity 0.3s;
-}
-
-#toast.show {
-  opacity: 1;
-}
-
-.hidden {
-  display: none;
-}
-
-footer {
-  text-align: center;
-  padding: 2rem 0;
-}
-
-footer .visits {
-  margin-top: 0.5rem;
-}
-
-@media (max-width: 600px) {
-  nav .menu {
-    display: none;
-    flex-direction: column;
-    width: 100%;
-    margin-top: 0.5rem;
-  }
-  nav .menu.open {
-    display: flex;
-  }
-  .menu-toggle {
-    display: block;
-  }
-}
-
-@media print {
-  nav, #theme-toggle, #accent-toggle, #download-btn, #toast, .menu-toggle {
-    display: none !important;
-  }
-  body {
-    background: #fff;
-    color: #000;
-  }
-}
-
+kbd { background: #222; color: #fff; border-radius: 4px; padding: 0 .35rem; margin: 0 .1rem; }


### PR DESCRIPTION
### Motivation
- Replace the previous curriculum-vitae single-page site with an interactive, browser-playable hyper-casual game inspired by the provided concept image to demonstrate a compact playable prototype. 
- Simplify the app surface to a focused game experience (HUD, canvas, controls) for easier iteration and testing.

### Description
- Replaced the site markup in `index.html` with a game layout containing HUD chips, a `<canvas id="game">` play area and a controls/status panel. 
- Added game-specific styling in `src/style.css` to present a desert-road runner look and make the canvas responsive and visually consistent. 
- Implemented the game loop and logic in `src/main.js` with 3-lane movement, automatic firing, row spawning (blue gates / red penalties), enemy rows with projectiles, score/coins/level progression, and game-over handling. 
- Removed CV UI/data wiring from the page and main script (the previous `cvData` population and many CV sections were removed to make room for the game code). 

### Testing
- Ran a production build with `npm run build`, which completed successfully. 
- Attempted an automated visual snapshot with Playwright after launching the preview, but Playwright browser binaries are not installed in this environment so the screenshot step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16a12591c8325a50cab674e9fedc6)